### PR TITLE
Add level choice to getCellIDs

### DIFF
--- a/R/getCellIDs.R
+++ b/R/getCellIDs.R
@@ -1,4 +1,4 @@
-getCellIDs = function(lat1, lon1, lat2, lon2) {
+getCellIDs = function(lat1, lon1, lat2, lon2, min_level = 0, max_level = 30) {
 
   library(reticulate)
 
@@ -10,6 +10,8 @@ getCellIDs = function(lat1, lon1, lat2, lon2) {
   p2 = s2sphere$LatLng$from_degrees(lat2, lon2)
 
   r = s2sphere$RegionCoverer()
+  r$min_level = min_level
+  r$max_level = max_level
   cell_ids = r$get_covering(s2sphere$LatLngRect$from_point_pair(p1, p2))
   cell_ids
 }


### PR DESCRIPTION
A small change which makes it possible to choose on which cell level you want to work. You have to set the min_level and the max_level (unfortunately the Python package does not give the option to give only a single level).

There are 30 different cell levels, ranging from an average cell resolution of 85011012.19 square kilometers to an average cell resolution of 0.74 square centimeters! See [here](http://s2geometry.io/resources/s2cell_statistics).

You can test with setting both max and min to 0. Then it will only return one cell ID.
You could also test with setting both max and min to 30. But i don't recommend, because your R will crash ;) (it will try to return the cell ID;s of cells with 0.74 square centimeter resolution that cover the rectangle).